### PR TITLE
Incluir algoritmo de analizar etiquetas.

### DIFF
--- a/esquemas/bekuo.json
+++ b/esquemas/bekuo.json
@@ -6,7 +6,7 @@
     },
     "Semáforo audible": {
         "crossing": "traffic_signals",
-        "traffic_signals:sound": ["walk","yes"]
+        "traffic_signals:sound": "walk;yes"
     },
     "Hidrante Seco": {
         "emergency": "fire_hydrant",

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -65,7 +65,7 @@ def mostrar_nodos_descargados(resultado, prefijo="\t", mostrar_etiquetas=True):
             for etiqueta in nodo.tags:
                 print(prefijo*2 + etiqueta, ' = ' + nodo.tags[etiqueta])
 
-
+#TODO Esta debe parsear el esquema en memoria en vez de mostrarlo
 def mostrar_esquema(ruta_esquema):
     with open(ruta_esquema) as esquema:
         data = json.load(esquema)
@@ -141,10 +141,29 @@ def imprimir_revisar(id, etiquetas_sobrantes):
            "en el esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
     print(msj.format(id, args.esquema, json.dumps(etiquetas_sobrantes, indent=4)))
 
-def imprimir_resultado(nodo,waypoint,estructura_analisis):
-    pass
 
+def imprimir_resultado(nodo,waypoint,estructura_analisis):
+    """
+    Recibe una estructura de anális retormada por ::analizar_etiquetas y los datos del nodo y
+    waypoint. Con base a esto decide cuál resultado debe ser impreso. 
+    """
+    caso = estructura_analisis[0]
+    etiquetas_analizadas = estructura_analisis[1]
+    if caso == "INFO":
+        imprimir_info(nodo.id)
+    elif caso == "EDITAR":
+        imprimir_editar(nodo.id,etiquetas_analizadas)
+    elif caso == "CREAR":
+        pass
+        # imprimir_crear()
+    else:
+        imprimir_revisar(nodo.id,etiquetas_analizadas)
+        
 def analizar_traza(ruta_gpx):
+    """
+    recibe una ruta a un archivo GPX.
+
+    """
     archivo_gpx = open(args.gpx, 'r')
     gpx = gpxpy.parse(archivo_gpx)
     # parsear esquema antes
@@ -154,11 +173,12 @@ def analizar_traza(ruta_gpx):
         # etiquetas_esquema = obtener etiquetas del esquema de mapeo asociado a nombre_waypoint
         for nodo in nodos_cercanos:     
             etiquetas_osm = nodo.tags
-            #estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
-            #imprimir_resultado(nodo,waypoint,estructura_analisis)
+            estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
+            imprimir_resultado(nodo,waypoint,estructura_analisis)
               
 
-def analizar_etiquetas(etiquetas_osm, etiquetas_esquema):
+
+def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict) -> list:
     """
     devuelve una estructura que tiene el (cod_caso,etiquetas_sobrantes||faltantes||necesarias||null)
     """
@@ -169,9 +189,9 @@ def analizar_etiquetas(etiquetas_osm, etiquetas_esquema):
             if valor_esquema == etiqueta_osm[etiqueta_osm]:
                 coincidencias +=1
     if len(etiqueta_osm) == len(etiquetas_esquema) and coincidencias == len(etiqueta_osm):
-        imprimir_info(id)
-
-    # caso info si etiquetas_osm y etiquetas_esquema son iguales
+        # caso info si etiquetas_osm y etiquetas_esquema son iguales
+        return ["INFO", None]
+    
     # caso editar si etiquetas_osm son mas que etiquetas_esquema
     # caso crear si etiquetas_osm y etiquetas_esquema no coinciden
     # caso revisar si etiquetas_esquema tiene mas que etiquetas_osm
@@ -179,8 +199,13 @@ def analizar_etiquetas(etiquetas_osm, etiquetas_esquema):
 
 if __name__ == "__main__":
     # mostrar waypoints del gpx de entrada
+    '''
     archivo_gpx = open(args.gpx, 'r')
     gpx = gpxpy.parse(archivo_gpx)
     archivo_gpx.close()
     mostrar_waypoints(gpx)
     mostrar_esquema(args.esquema)
+    '''
+    etiquetas_osm = {'amenity':'taxi'}
+    etiquetas_esquema = {'amenity':'taxi'}
+    analizar_etiquetas(etiquetas_osm, etiquetas_esquema)

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -141,6 +141,41 @@ def imprimir_revisar(id, etiquetas_sobrantes):
            "en el esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
     print(msj.format(id, args.esquema, json.dumps(etiquetas_sobrantes, indent=4)))
 
+def imprimir_resultado(nodo,waypoint,estructura_analisis):
+    pass
+
+def analizar_traza(ruta_gpx):
+    archivo_gpx = open(args.gpx, 'r')
+    gpx = gpxpy.parse(archivo_gpx)
+    # parsear esquema antes
+    for waypoint in gpx.waypoints:
+        nodos_cercanos = descargar_nodos_en_rango(waypoint.lat,waypoint.lon)
+        nombre_waypoint = waypoint.name
+        # etiquetas_esquema = obtener etiquetas del esquema de mapeo asociado a nombre_waypoint
+        for nodo in nodos_cercanos:     
+            etiquetas_osm = nodo.tags
+            #estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
+            #imprimir_resultado(nodo,waypoint,estructura_analisis)
+              
+
+def analizar_etiquetas(etiquetas_osm, etiquetas_esquema):
+    """
+    devuelve una estructura que tiene el (cod_caso,etiquetas_sobrantes||faltantes||necesarias||null)
+    """
+    coincidencias = 0
+    for etiqueta_osm in etiquetas_osm.keys():
+        if etiquetas_esquema.get(etiqueta_osm) != None:
+            valor_esquema = etiquetas_esquema[etiqueta_osm]
+            if valor_esquema == etiqueta_osm[etiqueta_osm]:
+                coincidencias +=1
+    if len(etiqueta_osm) == len(etiquetas_esquema) and coincidencias == len(etiqueta_osm):
+        imprimir_info(id)
+
+    # caso info si etiquetas_osm y etiquetas_esquema son iguales
+    # caso editar si etiquetas_osm son mas que etiquetas_esquema
+    # caso crear si etiquetas_osm y etiquetas_esquema no coinciden
+    # caso revisar si etiquetas_esquema tiene mas que etiquetas_osm
+
 
 if __name__ == "__main__":
     # mostrar waypoints del gpx de entrada

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -80,6 +80,30 @@ def mostrar_esquema(ruta_esquema):
                 print('Llave Nº{0} \'{1}:{2}\''.format(i+1, llave, valor))
 
 
+def imprimir_encabezado():
+    """
+    Muestra en pantalla un encabezado correspondiente a un informe de una
+    ruta de trazas brindadas y respectivo esquema.
+
+    No devuelve ningun valor.
+    """
+    msj = "Informe \n{0}\n\nAnalizando la ruta {1} con el esquema de mapeo {2}."
+    print(msj.format("="*8, args.gpx, args.esquema))
+
+
+def imprimir_crear(waypoint, etiquetas_nuevas):
+    """
+    Basado en un waypoint indica que se debe crear un nodo con ciertas etiquetas
+    en una coordenada especifica.
+
+    No devuelve ningun valor.
+    """
+
+    msj = "[CREAR] Se daba añadir un nuevo nodo en ({0}, {1}) con las etiquetas:\n{2}"
+    print(msj.format(waypoint.lat, waypoint.lon,
+                     json.dumps(etiquetas_nuevas, indent=4)))
+
+
 def imprimir_info(id):
     """
     Con base a un identificador de un nodo o vía en Open Street Map,imprime un
@@ -87,7 +111,9 @@ def imprimir_info(id):
 
     No devuelve ningun valor.
     """
-    print("[INFO] El nodo osm.org/node/"+str(id)+"está correctamente mapeado.")
+
+    msj = "[INFO] El nodo https://osm.org/node/{} está correctamente mapeado."
+    print(msj.format(id))
 
 
 def imprimir_editar(id, etiquetas_faltantes):
@@ -98,8 +124,9 @@ def imprimir_editar(id, etiquetas_faltantes):
 
     No devuelve ningun valor.
     """
-    print("[REVISAR] El nodo osm.org/node/"+str(id) +
-          "debe ser mejorado con las etiquetas: "+json.dumps(etiquetas_faltantes))
+
+    msj = "[REVISAR] El nodo https://osm.org/node/{0} debe ser mejorado con las etiquetas:\n{1}"
+    print(msj.format(id, json.dumps(etiquetas_faltantes, indent=4)))
 
 
 def imprimir_revisar(id, etiquetas_sobrantes):
@@ -109,10 +136,10 @@ def imprimir_revisar(id, etiquetas_sobrantes):
 
     No devuelve ningun valor.
     """
-    print("[REVISAR] El nodo osm.org/node/"+str(id) +
-          "tiene más etiquetas que las indicadas " +
-          "en el esquema de mapeo " + "esquemas/bekuo.json" +
-          "\nLas etiquetas demás son: "+json.dumps(etiquetas_sobrantes))
+
+    msj = ("[REVISAR] El nodo https://osm.org/node/{0} tiene más etiquetas que las indicadas "
+           "en el esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
+    print(msj.format(id, args.esquema, json.dumps(etiquetas_sobrantes, indent=4)))
 
 
 if __name__ == "__main__":

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -139,41 +139,6 @@ def imprimir_revisar(id, etiquetas_sobrantes):
            "en el esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
     print(msj.format(id, args.esquema, json.dumps(etiquetas_sobrantes, indent=4)[1:-1]))
 
-def imprimir_resultado(nodo,waypoint,estructura_analisis):
-    pass
-
-def analizar_traza(ruta_gpx):
-    archivo_gpx = open(args.gpx, 'r')
-    gpx = gpxpy.parse(archivo_gpx)
-    # parsear esquema antes
-    for waypoint in gpx.waypoints:
-        nodos_cercanos = descargar_nodos_en_rango(waypoint.lat,waypoint.lon)
-        nombre_waypoint = waypoint.name
-        # etiquetas_esquema = obtener etiquetas del esquema de mapeo asociado a nombre_waypoint
-        for nodo in nodos_cercanos:     
-            etiquetas_osm = nodo.tags
-            #estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
-            #imprimir_resultado(nodo,waypoint,estructura_analisis)
-              
-
-def analizar_etiquetas(etiquetas_osm, etiquetas_esquema):
-    """
-    devuelve una estructura que tiene el (cod_caso,etiquetas_sobrantes||faltantes||necesarias||null)
-    """
-    coincidencias = 0
-    for etiqueta_osm in etiquetas_osm.keys():
-        if etiquetas_esquema.get(etiqueta_osm) != None:
-            valor_esquema = etiquetas_esquema[etiqueta_osm]
-            if valor_esquema == etiqueta_osm[etiqueta_osm]:
-                coincidencias +=1
-    if len(etiqueta_osm) == len(etiquetas_esquema) and coincidencias == len(etiqueta_osm):
-        imprimir_info(id)
-
-    # caso info si etiquetas_osm y etiquetas_esquema son iguales
-    # caso editar si etiquetas_osm son mas que etiquetas_esquema
-    # caso crear si etiquetas_osm y etiquetas_esquema no coinciden
-    # caso revisar si etiquetas_esquema tiene mas que etiquetas_osm
-
 
 def imprimir_resultado(nodo,waypoint,estructura_analisis):
     """
@@ -206,22 +171,21 @@ def analizar_traza(ruta_gpx):
         # etiquetas_esquema = obtener etiquetas del esquema de mapeo asociado a nombre_waypoint
         for nodo in nodos_cercanos:     
             etiquetas_osm = nodo.tags
-            estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
-            imprimir_resultado(nodo,waypoint,estructura_analisis)
+            # estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
+            # imprimir_resultado(nodo,waypoint,estructura_analisis)
               
-
-
 def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict) -> list:
     """
     devuelve una estructura que tiene el (cod_caso,etiquetas_sobrantes||faltantes||necesarias||null)
     """
     coincidencias = 0
-    for etiqueta_osm in etiquetas_osm.keys():
-        if etiquetas_esquema.get(etiqueta_osm) != None:
-            valor_esquema = etiquetas_esquema[etiqueta_osm]
-            if valor_esquema == etiqueta_osm[etiqueta_osm]:
+    for llave_osm in etiquetas_osm.keys():
+        if etiquetas_esquema.get(llave_osm) != None:
+            valor_esquema = etiquetas_esquema[llave_osm]
+            valor_osm = etiquetas_osm[llave_osm]
+            if valor_esquema == valor_osm:
                 coincidencias +=1
-    if len(etiqueta_osm) == len(etiquetas_esquema) and coincidencias == len(etiqueta_osm):
+    if len(etiquetas_osm) == len(etiquetas_esquema) and coincidencias == len(etiquetas_osm):
         # caso info si etiquetas_osm y etiquetas_esquema son iguales
         return ["INFO", None]
     
@@ -241,4 +205,4 @@ if __name__ == "__main__":
     '''
     etiquetas_osm = {'amenity':'taxi'}
     etiquetas_esquema = {'amenity':'taxi'}
-    analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
+    print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -25,10 +25,11 @@ def mostrar_waypoints(gpx):
         print('\nWaypoint Encontrado {0} -> ({1},{2})'.
               format(waypoint.name, waypoint.latitude, waypoint.longitude))
 
-        nodos_alrededor = descargar_nodos_en_rango(waypoint.latitude, waypoint.longitude)
+        nodos_alrededor = descargar_nodos_en_rango(
+            waypoint.latitude, waypoint.longitude)
         if nodos_alrededor:
             print('\tNodos encontrados a {0}m del punto ({1},{2})'.format(args.rango,
-                  waypoint.latitude, waypoint.longitude))
+                                                                          waypoint.latitude, waypoint.longitude))
             mostrar_nodos_descargados(nodos_alrededor)
         else:
             print('\tNo hay nodos cerca del punto.')
@@ -53,7 +54,7 @@ def mostrar_nodos_descargados(resultado, prefijo="\t", mostrar_etiquetas=True):
     Dada una lista de objetos overpy.Node los imprime en un formato como el siguiente:
 
     [prefijo]https://osm.org/node/-ID del nodo-
-	[prefijo][prefijo]-etiqueta1- = -valor1-
+    [prefijo][prefijo]-etiqueta1- = -valor1-
     [prefijo][prefijo]-etiqueta2- = -valor2-
     ...
     [prefijo][prefijo]-etiquetaN- = -valorN-
@@ -62,7 +63,8 @@ def mostrar_nodos_descargados(resultado, prefijo="\t", mostrar_etiquetas=True):
         print(prefijo, "https://osm.org/node/" + str(nodo.id))
         if mostrar_etiquetas:
             for etiqueta in nodo.tags:
-                print(prefijo*2 +  etiqueta, ' = ' + nodo.tags[etiqueta])
+                print(prefijo*2 + etiqueta, ' = ' + nodo.tags[etiqueta])
+
 
 def mostrar_esquema(ruta_esquema):
     with open(ruta_esquema) as esquema:
@@ -76,6 +78,41 @@ def mostrar_esquema(ruta_esquema):
             for i, llave in enumerate(llaves):
                 valor = llaves[llave]
                 print('Llave Nº{0} \'{1}:{2}\''.format(i+1, llave, valor))
+
+
+def imprimir_info(id):
+    """
+    Con base a un identificador de un nodo o vía en Open Street Map,imprime un
+    mensaje de que el nodo se encuentra mapeado correctamente.
+
+    No devuelve ningun valor.
+    """
+    print("[INFO] El nodo osm.org/node/"+str(id)+"está correctamente mapeado.")
+
+
+def imprimir_editar(id, etiquetas_faltantes):
+    """
+    A partir de un identificador de un nodo, indica por medio de un mensaje que dicho
+    nodo debe ser mejorado con las etiquetas de la forma {llave1:valor1...llaveN:valorN}
+    encontradas en el esquema de mapeo.
+
+    No devuelve ningun valor.
+    """
+    print("[REVISAR] El nodo osm.org/node/"+str(id) +
+          "debe ser mejorado con las etiquetas: "+json.dumps(etiquetas_faltantes))
+
+
+def imprimir_revisar(id, etiquetas_sobrantes):
+    """
+    Segun un identificador de un nodo, muestra un mensaje que el elemento tiene mayor cantidad
+    de etiquetas {llave1:valor1...llaveN:valorN} a las que corresponde en el esquema de mapeo.
+
+    No devuelve ningun valor.
+    """
+    print("[REVISAR] El nodo osm.org/node/"+str(id) +
+          "tiene más etiquetas que las indicadas " +
+          "en el esquema de mapeo " + "esquemas/bekuo.json" +
+          "\nLas etiquetas demás son: "+json.dumps(etiquetas_sobrantes))
 
 
 if __name__ == "__main__":

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -15,6 +15,8 @@ parser.add_argument('--esquema', '-e', metavar='',
 parser.add_argument('--rango', '-r', metavar='', required=False, default=20,
                     type=int, help='radio en metros de la circunferencia donde se descargarán los '
                     + 'elementos de OSM')
+parser.add_argument('--debug', '-d', metavar='', required=False, default=False,
+                    type=bool, help='mostrar mensajes de depuración')
 
 args = parser.parse_args()
 
@@ -28,7 +30,7 @@ def parsear_esquema():
     """
     with open(args.esquema) as archivo_esquema:
         esquema_parseado = json.load(archivo_esquema)
-    
+
     return esquema_parseado
 
 
@@ -47,7 +49,7 @@ def mostrar_waypoints(gpx):
             print('\tNo hay nodos cerca del punto.')
 
 
-def descargar_nodos_en_rango(lat, lon):
+def descargar_nodos_en_rango(lat, lon, debug=False):
     """
     A partir de un punto (lat, lon) dado como argumento, descarga todos los nodos que se encuentren
     a una distancia de 'rango' metros.
@@ -58,6 +60,8 @@ def descargar_nodos_en_rango(lat, lon):
     # Consulta descarga nodos, pero si se cambia "node" por "nwr" descarga vías y relaciones.
     consulta = "node(around:%s, %s, %s); out;" % (args.rango, lat, lon)
     resultado = api.query(consulta)
+    if debug:
+        mostrar_nodos_descargados(resultado)
     return resultado
 
 
@@ -71,12 +75,13 @@ def mostrar_nodos_descargados(resultado, prefijo="\t", mostrar_etiquetas=True):
     ...
     [prefijo][prefijo]-etiquetaN- = -valorN-
     """
+    debug_preambulo = "DEBUG (mostrar_nodos_descargados): "
+    print(debug_preambulo + "Se descargaron " + str(len(resultado.nodes)) + " nodos.")
     for nodo in resultado.nodes:
-        print(prefijo, "https://osm.org/node/" + str(nodo.id))
+        print(debug_preambulo + prefijo + "https://osm.org/node/" + str(nodo.id))
         if mostrar_etiquetas:
             for etiqueta in nodo.tags:
-                print(prefijo*2 + etiqueta, ' = ' + nodo.tags[etiqueta])
-
+                print(debug_preambulo + prefijo*2 + etiqueta, ' = ' + nodo.tags[etiqueta])
 
 def imprimir_encabezado():
     """
@@ -87,6 +92,15 @@ def imprimir_encabezado():
     """
     msj = "Informe \n{0}\n\nAnalizando la ruta {1} con el esquema de mapeo {2}."
     print(msj.format("="*8, args.gpx, args.esquema))
+
+def imprimir_encabezado_waypoint(wpt_nombre, wpt_lat, wpt_lon):
+    """
+    Muestra en pantalla un encabezado correspondiente a un informe del análisis de un waypoiont.
+
+    No devuelve ningun valor.
+    """
+    msj = "\n\nAnalizando el waypoint con nombre '{0}' ubicado en {1},{2}."
+    print(msj.format(wpt_nombre, wpt_lat, wpt_lon))
 
 
 def imprimir_crear(latitud, longitud, etiquetas_nuevas):
@@ -138,7 +152,7 @@ def imprimir_revisar(id, etiquetas_sobrantes):
 def imprimir_resultado(nodo,waypoint,estructura_analisis):
     """
     Recibe una estructura de anális retormada por analizar_etiquetas y los datos del nodo y
-    waypoint. Con base a esto decide cuál resultado debe ser impreso. 
+    waypoint. Con base a esto decide cuál resultado debe ser impreso.
 
     No devuelve ningun valor.
     """
@@ -150,55 +164,103 @@ def imprimir_resultado(nodo,waypoint,estructura_analisis):
         imprimir_editar(nodo.id,etiquetas_analizadas)
     elif caso == "CREAR":
         imprimir_crear(waypoint.latitude,waypoint.longitude,etiquetas_analizadas)
-    else:
+    elif caso == "INFO":
         imprimir_info(nodo.id)
-        
-def analizar_traza(ruta_gpx):
+    else:
+        print("Nada por hacer")
+
+
+def analizar_traza(ruta_gpx, debug=False):
     """
     Recibe una ruta a un archivo GPX el cual cada uno de sus waypoints debe ser analizado.
 
-    No devuelve ningún valor
+    No devuelve ningún valor. Imprime en pantalla los resultados del análisis apoyándose en las
+    funciones auxiliares.
     """
-    archivo_gpx = open(args.gpx, 'r')
+    archivo_gpx = open(ruta_gpx, 'r')
     gpx = gpxpy.parse(archivo_gpx)
     # parsear esquema antes
     for waypoint in gpx.waypoints:
-        nodos_cercanos = descargar_nodos_en_rango(waypoint.lat,waypoint.lon)
+        nodos_cercanos = descargar_nodos_en_rango(waypoint.latitude,waypoint.longitude, debug)
         nombre_waypoint = waypoint.name
+        imprimir_encabezado_waypoint(nombre_waypoint, waypoint.latitude, waypoint.longitude)
         etiquetas_esquema = esquema_mapeo_global[nombre_waypoint]
-        for nodo in nodos_cercanos:     
+        resultados_analisis = list()
+        for nodo in nodos_cercanos.nodes:
             etiquetas_osm = nodo.tags
-            estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema)
-            imprimir_resultado(nodo,waypoint,estructura_analisis)
-              
-def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict) -> list:
+            estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema, debug)
+            if estructura_analisis[0] != "NADA":
+                resultados_analisis.append(estructura_analisis)
+                imprimir_resultado(nodo,waypoint,estructura_analisis)
+
+        if resultados_analisis == []:
+            # CREAR
+            imprimir_resultado(nodo,waypoint,["CREAR", etiquetas_esquema])
+
+    archivo_gpx.close()
+
+
+def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict,debug=True) -> list:
     """
     Segun las etiquetas en osm cercanas y las etiquetas en el esquema de cierto waypoint,
-    analiza si las etiquetas de osm se encuentran correctamente mapeadas o viceversa.
-    
-    Devuelve una estructura una lista con el formato
-    [cod_caso,etiquetas_sobrantes||faltantes||necesarias||null]
+    si las ambos dicciones son iguales (INFO), si hay al menos una coinciddncia en una etiqueta pero
+    hay ḿas etiquetas en el esquema (EDITAR), si hay condicen todas las etiquetas entre ambos
+    diccionario pero hay algunas adicionales en OSM (REVISAR). Si ninguno de los tres casos está
+    presente entonces se devuelve el código de caso NADA con etiqueta nulas.
+
+    Devuelve una estructura una lista con el formato:
+
+    [codigo_caso, etiquetas]
+
+    etiquetas será una opción entre: etiquetas_sobrantes||faltantes||necesarias||null
     """
+
+    debug_preambulo = "DEBUG (analizar_etiquetas): "
+
+    if debug:
+        print("\n\n")
+        print(debug_preambulo + "etiquetas_osm: " + str(etiquetas_osm))
+        print(debug_preambulo + "etiquetas_esquema: " + str(etiquetas_esquema))
     total_osm = len(etiquetas_osm)
     total_esquema = len(etiquetas_esquema)
 
     coincidencias = dict(etiquetas_osm.items() & etiquetas_esquema.items())
-    faltantes = dict(etiquetas_osm.items() - etiquetas_esquema.items())
-    sobrantes = dict(etiquetas_esquema.items() - etiquetas_osm.items())
+    # "fsobrantes_en_osm": están en OSM y no en el esquema.
+    sobrantes_en_osm = dict(etiquetas_osm.items() - etiquetas_esquema.items())
+    # sobrantes_esquema: están en el esquema y no en OSM
+    sobrantes_esquema = dict(etiquetas_esquema.items() - etiquetas_osm.items())
 
+    # INFO
     if total_esquema == total_osm and total_osm == len(coincidencias):
         # caso info si etiquetas_osm y etiquetas_esquema son iguales
+        if debug:
+            print(debug_preambulo + "INFO" + str(None))
         return ["INFO", None]
-    elif len(faltantes) >= len(coincidencias):
+
+    # EDITAR
+    elif len(coincidencias) >= 1 and len(sobrantes_esquema) >= 1:
         # caso editar si etiquetas_osm son mas que etiquetas_esquema
-        return ["EDITAR",faltantes]
-    elif len(coincidencias) == 0:
-        # caso crear si etiquetas_osm y etiquetas_esquema no coinciden
-        return ["CREAR",etiquetas_esquema]
-    elif len(sobrantes) >= len(coincidencias):
-        # caso crear si etiquetas_esquema  son mas que etiquetas_osm
-        return ["REVISAR",sobrantes]
-    
+        if debug:
+            print(debug_preambulo + "EDITAR" + str(sobrantes_esquema))
+        return ["EDITAR", sobrantes_esquema]
+
+    # REVISAR
+    elif len(coincidencias) == total_esquema and len(sobrantes_en_osm) > 0:
+        # caso crear si etiquetas_esquema son mas que etiquetas_osm
+        if debug:
+            print(debug_preambulo + "REVISAR" + str(sobrantes_en_osm))
+        return ["REVISAR", sobrantes_en_osm]
+
+    # NADA: candidato a caso de CREAR
+    else:
+        if debug:
+            print(debug_preambulo + "CASO NO CONTEMPLADO")
+            print(debug_preambulo + "total_osm: " + str(total_osm))
+            print(debug_preambulo + "total_esquema: " + str(total_esquema))
+            print(debug_preambulo + "coincidencias " + str(coincidencias))
+            print(debug_preambulo + "sobrantes_en_osm: " + str(sobrantes_en_osm))
+            print(debug_preambulo + "sobrantes_esquema: " + str(sobrantes_esquema))
+        return ["NADA", None]
 
 esquema_mapeo_global = parsear_esquema()
 
@@ -210,6 +272,22 @@ if __name__ == "__main__":
     mostrar_waypoints(gpx)
     mostrar_esquema(args.esquema)
     '''
-    etiquetas_osm = {'amenity':'taxi'}
-    etiquetas_esquema = {'amenity':'taxi'}
-    print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
+    ruta_gpx = args.gpx
+    debug = args.debug
+
+    #caso info
+    #etiquetas_osm = {'amenity':'taxi'}
+    #etiquetas_esquema = {'amenity':'taxi'}
+    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
+
+    # caso editar
+    #etiquetas_osm ={'crossing': 'traffic_signals', 'highway': 'traffic_signals', 'traffic_signals': 'crossing'}
+    #etiquetas_esquema = {'crossing': 'traffic_signals', 'traffic_signals:sound': 'walk;yes'}
+    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
+
+    # caso revisar
+    #etiquetas_osm = {'bench': 'yes', 'bus': 'yes', 'covered': 'yes', 'highway': 'bus_stop', 'name': 'UNADECA', 'public_transport': 'platform', 'shelter': 'yes'}
+    #etiquetas_esquema = {'public_transport': 'platform', 'bench': 'yes', 'shelter': 'yes', 'bus': 'yes'}
+    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
+
+    analizar_traza(ruta_gpx, debug)

--- a/trazas/prueba_crear.gpx
+++ b/trazas/prueba_crear.gpx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<metadata>
+		<name>2021-02-21_10-03-23</name>
+		<keywords>bekuo</keywords>
+		<keywords>osmtracker</keywords>
+	</metadata>
+	<wpt lat="10.029784051128404" lon="-84.21501124721962">
+		<ele>999.4496285114437</ele>
+		<time>2021-02-21T16:16:05Z</time>
+		<name><![CDATA[Semáforo audible]]></name>
+		<sat>15</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.022602596416741" lon="-84.21667112741552">
+				<ele>960.429022083059</ele>
+				<time>2021-02-21T16:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/trazas/prueba_editar.gpx
+++ b/trazas/prueba_editar.gpx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<metadata>
+		<name>2021-02-21_10-03-23</name>
+		<keywords>bekuo</keywords>
+		<keywords>osmtracker</keywords>
+	</metadata>
+	<wpt lat="10.02766919787807" lon="-84.21556624669424">
+		<ele>985.6528039621189</ele>
+		<time>2021-02-21T16:20:26Z</time>
+		<name><![CDATA[Semáforo audible]]></name>
+		<sat>15</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.022602596416741" lon="-84.21667112741552">
+				<ele>960.429022083059</ele>
+				<time>2021-02-21T16:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/trazas/prueba_info.gpx
+++ b/trazas/prueba_info.gpx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<metadata>
+		<name>2021-02-21_10-03-23</name>
+		<keywords>bekuo</keywords>
+		<keywords>osmtracker</keywords>
+	</metadata>
+	<wpt lat="10.027898339757584" lon="-84.21553829520037">
+		<ele>985.4100807439536</ele>
+		<time>2021-02-21T16:20:02Z</time>
+		<name><![CDATA[Taxis]]></name>
+		<sat>15</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.022602596416741" lon="-84.21667112741552">
+				<ele>960.429022083059</ele>
+				<time>2021-02-21T16:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/trazas/prueba_revisar.gpx
+++ b/trazas/prueba_revisar.gpx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<metadata>
+		<name>2021-02-21_10-03-23</name>
+		<keywords>bekuo</keywords>
+		<keywords>osmtracker</keywords>
+	</metadata>
+	<wpt lat="10.032290950935142" lon="-84.21384352327117">
+		<ele>998.0827697096393</ele>
+		<time>2021-02-21T16:04:02Z</time>
+		<name><![CDATA[Parada de Bus - Tipo 3]]></name>
+		<sat>15</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.022602596416741" lon="-84.21667112741552">
+				<ele>960.429022083059</ele>
+				<time>2021-02-21T16:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>


### PR DESCRIPTION
En el PR van incluidos los 4 casos correspondientes que puede incluir un waypoint en la traza gpx.

En esta implementación del algoritmo `analizar_etiquetas`, se utilizan operaciones entre diccionarios con las `etiquetas_osm` y `etiquetas_esquema`.
Las variables nuevas que se tomaron en cuenta son:

- `coincidencias`: Las valores encontrados en ambos diccionarios.
- `faltantes`:  Las valores encontrados en `etiquetas_osm` pero no en `etiquetas_esquema`.
- `sobrantes`:  Las valores encontrados en `etiquetas_esquema` pero no en `etiquetas_osm`.