### PR TITLE
Formato de código y mejora de imprimir resultado.

### DIFF
--- a/pre_editor.py
+++ b/pre_editor.py
@@ -1,4 +1,3 @@
-import os
 import json
 import argparse
 import gpxpy
@@ -6,22 +5,24 @@ import overpy
 
 # Manejar entradas
 parser = argparse.ArgumentParser(
-    prog='Pre-editor OSM', description='Analizar trazas capturadas antes de editarlas en OSM')
+    prog='Pre-editor OSM',
+    description='Analizar trazas capturadas antes de editarlas en OSM')
 
 parser.add_argument('--gpx', '-g', metavar='', required=True,
                     help="ruta a lo(s) archivo(s) gpx a analizar")
 parser.add_argument('--esquema', '-e', metavar='',
                     required=True, help="ruta del esquema de mapeo")
-parser.add_argument('--rango', '-r', metavar='', required=False, default=20,
-                    type=int, help='radio en metros de la circunferencia donde se descargarán los '
-                    + 'elementos de OSM')
+parser.add_argument('--rango', '-r', metavar='', required=False,
+                    default=20, type=int,
+                    help='radio en metros de la circunferencia donde' +
+                    'se descargarán los elementos de OSM')
 parser.add_argument('--debug', '-d', metavar='', required=False, default=False,
                     type=bool, help='mostrar mensajes de depuración')
 
 args = parser.parse_args()
 
 
-def parsear_esquema():
+def parsear_esquema() -> dict:
     """
     Se encarga de convertir la ruta del esquema de entrada al programa
     a un diccionario de datos.
@@ -34,30 +35,18 @@ def parsear_esquema():
     return esquema_parseado
 
 
-def mostrar_waypoints(gpx):
-    print('{0}Informacion de GPX{0}'.format("-"*10))
-    for waypoint in gpx.waypoints:
-        print('\nWaypoint Encontrado {0} -> ({1},{2})'.
-              format(waypoint.name, waypoint.latitude, waypoint.longitude))
-
-        nodos_alrededor = descargar_nodos_en_rango(waypoint.latitude, waypoint.longitude)
-        if nodos_alrededor:
-            print('\tNodos encontrados a {0}m del punto ({1},{2})'.format(args.rango,
-                  waypoint.latitude, waypoint.longitude))
-            mostrar_nodos_descargados(nodos_alrededor)
-        else:
-            print('\tNo hay nodos cerca del punto.')
-
-
-def descargar_nodos_en_rango(lat, lon, debug=False):
+def descargar_nodos_en_rango(lat: float, lon: float, debug=False) -> list:
     """
-    A partir de un punto (lat, lon) dado como argumento, descarga todos los nodos que se encuentren
-    a una distancia de 'rango' metros.
+    A partir de un punto (lat, lon) dado como argumento, descarga
+    todos los nodos que se encuentren a una distancia de 'rango'
+    metros.
 
     Devuelve una lista de objetos overpy.Node.
     """
     api = overpy.Overpass()
-    # Consulta descarga nodos, pero si se cambia "node" por "nwr" descarga vías y relaciones.
+
+    # Consulta descarga nodos, pero si se cambia "node"
+    # por "nwr" descarga vías y relaciones.
     consulta = "node(around:%s, %s, %s); out;" % (args.rango, lat, lon)
     resultado = api.query(consulta)
     if debug:
@@ -65,167 +54,223 @@ def descargar_nodos_en_rango(lat, lon, debug=False):
     return resultado
 
 
-def mostrar_nodos_descargados(resultado, prefijo="\t", mostrar_etiquetas=True):
+def mostrar_nodos_descargados(resultado: list, mostrar_etiquetas=True) -> None:
     """
-    Dada una lista de objetos overpy.Node los imprime en un formato como el siguiente:
+    Dada una lista de objetos overpy.Node los imprime en un
+    formato como el siguiente:
 
-    [prefijo]https://osm.org/node/-ID del nodo-
-    [prefijo][prefijo]-etiqueta1- = -valor1-
-    [prefijo][prefijo]-etiqueta2- = -valor2-
+    [TAB]https://osm.org/node/-ID del nodo-
+    [TAB][TAB]etiqueta1 => valor1
+    [TAB][TAB]etiqueta2 => valor2
     ...
-    [prefijo][prefijo]-etiquetaN- = -valorN-
+    [TAB][TAB]etiquetaN => valorN
     """
     debug_preambulo = "DEBUG (mostrar_nodos_descargados): "
-    print(debug_preambulo + "Se descargaron " + str(len(resultado.nodes)) + " nodos.")
+    url = "https://osm.org/node/"
+    print('{0} Se descargaron {1} nodos.'.
+          format(debug_preambulo, len(resultado.nodes)))
     for nodo in resultado.nodes:
-        print(debug_preambulo + prefijo + "https://osm.org/node/" + str(nodo.id))
+        print('{:>10}{}'.format(url, nodo.id))
         if mostrar_etiquetas:
-            for etiqueta in nodo.tags:
-                print(debug_preambulo + prefijo*2 + etiqueta, ' = ' + nodo.tags[etiqueta])
+            for llave, valor in nodo.tags.items():
+                print('{:>10} => {:>10}'.format(llave, valor))
 
-def imprimir_encabezado():
+
+def imprimir_encabezado_traza(ruta_gpx: str) -> None:
     """
-    Muestra en pantalla un encabezado correspondiente a un informe de una
-    ruta de trazas brindadas y respectivo esquema.
+    Muestra en pantalla un encabezado correspondiente a un
+    informe de una ruta de traza gpx brindada y
+    la ruta del esquema enviada por terminal.
 
     No devuelve ningun valor.
     """
-    msj = "Informe \n{0}\n\nAnalizando la ruta {1} con el esquema de mapeo {2}."
-    print(msj.format("="*8, args.gpx, args.esquema))
+    msj = "Informe \n{0}\n\nAnalizando la ruta {1} con el esquema de mapeo {2}"
+    print(msj.format("="*8, ruta_gpx, args.esquema))
 
-def imprimir_encabezado_waypoint(wpt_nombre, wpt_lat, wpt_lon):
+
+def imprimir_encabezado_waypoint(nombre: str,
+                                 latitud: float,
+                                 longitud: float) -> None:
     """
-    Muestra en pantalla un encabezado correspondiente a un informe del análisis de un waypoiont.
+    Muestra en pantalla un encabezado correspondiente
+    a un informe del análisis de un waypoint.
 
     No devuelve ningun valor.
     """
-    msj = "\n\nAnalizando el waypoint con nombre '{0}' ubicado en {1},{2}."
-    print(msj.format(wpt_nombre, wpt_lat, wpt_lon))
+    msj = "\n\nAnalizando el waypoint con nombre '{0}' ubicado en ({1},{2})."
+    print(msj.format(nombre, latitud, longitud))
 
 
-def imprimir_crear(latitud, longitud, etiquetas_nuevas):
+def imprimir_crear(latitud, longitud, etiquetas_nuevas) -> None:
     """
-    Basado en una latitud y longitudt indica que se debe crear un nodo con ciertas etiquetas
-    en esa coordenada especifica.
+    Basado en una latitud y longitud indica que se debe crear un
+    nodo con ciertas etiquetas en esa coordenada especifica.
 
     No devuelve ningun valor.
     """
-    msj = "[CREAR] Se debe añadir un nuevo nodo en ({0}, {1}) con las etiquetas:\n{2}"
-    print(msj.format(latitud, longitud, json.dumps(etiquetas_nuevas, indent=4)[1:-1]))
+    msj = ("[CREAR] Se debe añadir un nuevo nodo en ({0}, {1})"
+           " con las etiquetas:\n{2}")
+    print(msj.format(latitud, longitud, json.dumps(
+        etiquetas_nuevas, indent=4)[1:-1]))
 
 
-def imprimir_info(id):
+def imprimir_info(argumentos_imprimir: (int, dict, float, float)) -> None:
     """
-    Con base a un identificador de un nodo o vía en Open Street Map,imprime un
-    mensaje de que el nodo se encuentra mapeado correctamente.
+    Con base a los argumentos de imprimir, obtiene
+    el indentificador de un nodo o vía en Open Street Map e
+    imprime un mensaje de que el nodo se encuentra
+    mapeado correctamente.
 
     No devuelve ningun valor.
     """
-    msj = "[INFO] El nodo https://osm.org/node/{} está correctamente mapeado."
+    id = argumentos_imprimir[0]
+    msj = ("[INFO] El nodo https://osm.org/node/{}"
+           " está correctamente mapeado.")
     print(msj.format(id))
 
 
-def imprimir_editar(id, etiquetas_faltantes):
+def imprimir_editar(argumentos_imprimir: (int, dict, float, float)) -> None:
     """
-    A partir de un identificador de un nodo, indica por medio de un mensaje que dicho
-    nodo debe ser mejorado con las etiquetas de la forma {llave1:valor1...llaveN:valorN}
+    A partir de los argumentos de imprimir, obtiene las
+    etiquetas faltantes y el identificador de nodo
+    para indicar en pantalla que debe ser mejorado con las
+    etiquetas de la forma {llave1:valor1...llaveN:valorN}
     encontradas en el esquema de mapeo.
 
     No devuelve ningun valor.
     """
-    msj = "[EDITAR] El nodo https://osm.org/node/{0} debe ser mejorado con las etiquetas:\n{1}"
+    id, etiquetas_faltantes, _, _ = argumentos_imprimir
+    msj = ("[EDITAR] El nodo https://osm.org/node/{0}"
+           "debe ser mejorado con las etiquetas:\n{1}")
     print(msj.format(id, json.dumps(etiquetas_faltantes, indent=4)[1:-1]))
 
 
-def imprimir_revisar(id, etiquetas_sobrantes):
+def imprimir_revisar(argumentos_imprimir: (int, dict, float, float)) -> None:
     """
-    Indica que cierto nodo con identificador brindado posee mayor cantidad de etiquetas
-    a las que corresponde en el esquema de mapeo y por lo tanto debe ser revisado.
+
+    Según los argumentos de imprimir, consigue las
+    etiquetas  sobrantes y el identificador de nodo
+    para imprimir en pantalla que el nodo cuenta con una
+    mayor cantidad de etiquetas a las que corresponde en el
+    esquema de mapeo y por lo tanto debe ser revisado.
 
     No devuelve ningun valor.
     """
-    msj = ("[REVISAR] El nodo https://osm.org/node/{0} tiene más etiquetas que las indicadas "
-           "en el esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
-    print(msj.format(id, args.esquema, json.dumps(etiquetas_sobrantes, indent=4)[1:-1]))
+    id, etiquetas_sobrantes, _, _ = argumentos_imprimir
+    msj = ("[REVISAR] El nodo https://osm.org/node/{0}"
+           "tiene más etiquetas que las indicadas en el"
+           "esquema de mapeo {1}\nLas etiquetas demás son:\n{2}")
+    print(msj.format(id, args.esquema, json.dumps(
+        etiquetas_sobrantes, indent=4)[1:-1]))
 
 
-def imprimir_resultado(nodo,waypoint,estructura_analisis):
+def imprimir_resultado(resultado: tuple, id: int,
+                       latitud: float, longitud: float) -> None:
     """
-    Recibe una estructura de anális retormada por analizar_etiquetas y los datos del nodo y
-    waypoint. Con base a esto decide cuál resultado debe ser impreso.
+    Recibe un resultado retornado de la forma
+    (funcion_imprimir, etiquetas_analizadas),
+    un identificador y la latitud y longitud del waypoint.
+
+    Con base a esto decide cuál funcion debe ser llamada
+    para imprimir el resultado.
 
     No devuelve ningun valor.
     """
-    caso = estructura_analisis[0]
-    etiquetas_analizadas = estructura_analisis[1]
-    if caso == "REVISAR":
-        imprimir_revisar(nodo.id,etiquetas_analizadas)
-    elif caso == "EDITAR":
-        imprimir_editar(nodo.id,etiquetas_analizadas)
-    elif caso == "CREAR":
-        imprimir_crear(waypoint.latitude,waypoint.longitude,etiquetas_analizadas)
-    elif caso == "INFO":
-        imprimir_info(nodo.id)
-    else:
-        print("Nada por hacer")
+    funcion_imprimir, etiquetas_analizadas = resultado
+    argumentos_imprimir = (id, etiquetas_analizadas, latitud, longitud)
+    funcion_imprimir(argumentos_imprimir)
 
 
-def analizar_traza(ruta_gpx, debug=False):
+def analizar_traza(ruta_gpx: str, debug=False) -> None:
     """
-    Recibe una ruta a un archivo GPX el cual cada uno de sus waypoints debe ser analizado.
+    Recibe una ruta a un archivo GPX el cual cada uno de sus
+    waypoints debe ser analizado.
 
-    No devuelve ningún valor. Imprime en pantalla los resultados del análisis apoyándose en las
-    funciones auxiliares.
+    Imprime en pantalla los resultados del análisis apoyándose en las
+    en los argumentos recibidos por el análisis de etiquetas.
+
+    No devuelve ningún valor.
     """
+
+    imprimir_encabezado_traza(ruta_gpx)
+
+    # Parsear el gpx
     archivo_gpx = open(ruta_gpx, 'r')
     gpx = gpxpy.parse(archivo_gpx)
-    # parsear esquema antes
-    for waypoint in gpx.waypoints:
-        nodos_cercanos = descargar_nodos_en_rango(waypoint.latitude,waypoint.longitude, debug)
-        nombre_waypoint = waypoint.name
-        imprimir_encabezado_waypoint(nombre_waypoint, waypoint.latitude, waypoint.longitude)
-        etiquetas_esquema = esquema_mapeo_global[nombre_waypoint]
-        resultados_analisis = list()
-        for nodo in nodos_cercanos.nodes:
-            etiquetas_osm = nodo.tags
-            estructura_analisis = analizar_etiquetas(etiquetas_osm, etiquetas_esquema, debug)
-            if estructura_analisis[0] != "NADA":
-                resultados_analisis.append(estructura_analisis)
-                imprimir_resultado(nodo,waypoint,estructura_analisis)
-
-        if resultados_analisis == []:
-            # CREAR
-            imprimir_resultado(nodo,waypoint,["CREAR", etiquetas_esquema])
-
     archivo_gpx.close()
 
+    for waypoint in gpx.waypoints:
 
-def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict,debug=True) -> list:
+        # Obtener los atributos del waypoint
+        latitud = waypoint.latitude
+        longitud = waypoint.longitude
+        nombre = waypoint.name
+
+        # Mostrar informacion del waypoint
+        nodos_cercanos = descargar_nodos_en_rango(latitud, longitud, debug)
+        imprimir_encabezado_waypoint(nombre, latitud, longitud)
+
+        # Se asume que las etiquetas del waypoint no se encuentran en OSM
+        nodo_es_nuevo = True
+
+        # Si no hay etiquetas en el esquema con ese nombre se omite
+        etiquetas_esquema = esquema.get(nombre)
+        if etiquetas_esquema is not None:
+            for nodo in nodos_cercanos.nodes:
+                etiquetas_osm = nodo.tags
+                resultado = analizar_etiquetas(
+                    etiquetas_osm, etiquetas_esquema, debug)
+
+                # Si el resultado fue un caso esperado quiere decir que
+                # las etiquetas analizadas ya estaban en OSM
+                if resultado is not None:
+                    nodo_es_nuevo = False
+                    imprimir_resultado(resultado, nodo.id, latitud, longitud)
+
+            if nodo_es_nuevo:
+                imprimir_crear(latitud, longitud, etiquetas_esquema)
+
+
+def analizar_etiquetas(etiquetas_osm: dict,
+                       etiquetas_esquema: dict, debug=True) -> tuple:
     """
-    Segun las etiquetas en osm cercanas y las etiquetas en el esquema de cierto waypoint,
-    si las ambos dicciones son iguales (INFO), si hay al menos una coinciddncia en una etiqueta pero
-    hay ḿas etiquetas en el esquema (EDITAR), si hay condicen todas las etiquetas entre ambos
-    diccionario pero hay algunas adicionales en OSM (REVISAR). Si ninguno de los tres casos está
-    presente entonces se devuelve el código de caso NADA con etiqueta nulas.
+    Segun las etiquetas en osm cercanas y las etiquetas en el
+    esquema de cierto waypoint, determina cual es la funcion
+    que se debe llamar para mostrar en pantalla las etiquetas
+    analizadas
 
-    Devuelve una estructura una lista con el formato:
+    Si las ambos dicciones son iguales (INFO),
 
-    [codigo_caso, etiquetas]
+    Si hay al menos una coincidencia en una etiqueta pero
+    hay ḿas etiquetas en el esquema (EDITAR)
 
-    etiquetas será una opción entre: etiquetas_sobrantes||faltantes||necesarias||null
+    Si hay condicen todas las etiquetas entre ambos
+    diccionarios pero hay algunas adicionales en OSM (REVISAR)
+
+    Si ninguno de los tres casos está presente entonces se
+    devuelve un resultado vacio
+
+    Devuelve una tupla de resultado con el formato:
+
+    (funcion_imprimir, etiquetas)
+
+    etiquetas será una opción entre:
+    etiquetas_sobrantes||faltantes||necesarias||None
+
+    funcion_imprimir será una opción entre imprimir_:
+    info||editar||revisar||None
     """
 
     debug_preambulo = "DEBUG (analizar_etiquetas): "
 
     if debug:
-        print("\n\n")
-        print(debug_preambulo + "etiquetas_osm: " + str(etiquetas_osm))
-        print(debug_preambulo + "etiquetas_esquema: " + str(etiquetas_esquema))
+        print('\n\n {0} etiquetas_osm: {1} etiquetas_esquema{2}'
+              .format(debug_preambulo, etiquetas_osm, etiquetas_esquema))
     total_osm = len(etiquetas_osm)
     total_esquema = len(etiquetas_esquema)
 
     coincidencias = dict(etiquetas_osm.items() & etiquetas_esquema.items())
-    # "fsobrantes_en_osm": están en OSM y no en el esquema.
+    # "sobrantes_en_osm": están en OSM y no en el esquema.
     sobrantes_en_osm = dict(etiquetas_osm.items() - etiquetas_esquema.items())
     # sobrantes_esquema: están en el esquema y no en OSM
     sobrantes_esquema = dict(etiquetas_esquema.items() - etiquetas_osm.items())
@@ -234,60 +279,41 @@ def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict,debug=True) 
     if total_esquema == total_osm and total_osm == len(coincidencias):
         # caso info si etiquetas_osm y etiquetas_esquema son iguales
         if debug:
-            print(debug_preambulo + "INFO" + str(None))
-        return ["INFO", None]
+            print('{0} INFO (None)'.format(debug_preambulo))
+        return (imprimir_info, None)
 
     # EDITAR
     elif len(coincidencias) >= 1 and len(sobrantes_esquema) >= 1:
         # caso editar si etiquetas_osm son mas que etiquetas_esquema
         if debug:
-            print(debug_preambulo + "EDITAR" + str(sobrantes_esquema))
-        return ["EDITAR", sobrantes_esquema]
+            print('{0} EDITAR {1}'.format(debug_preambulo, sobrantes_esquema))
+        return (imprimir_editar, sobrantes_esquema)
 
     # REVISAR
     elif len(coincidencias) == total_esquema and len(sobrantes_en_osm) > 0:
         # caso crear si etiquetas_esquema son mas que etiquetas_osm
         if debug:
-            print(debug_preambulo + "REVISAR" + str(sobrantes_en_osm))
-        return ["REVISAR", sobrantes_en_osm]
+            print('{0} REVISAR {1}'.format(debug_preambulo, sobrantes_en_osm))
+        return (imprimir_revisar, sobrantes_en_osm)
 
     # NADA: candidato a caso de CREAR
     else:
         if debug:
-            print(debug_preambulo + "CASO NO CONTEMPLADO")
-            print(debug_preambulo + "total_osm: " + str(total_osm))
-            print(debug_preambulo + "total_esquema: " + str(total_esquema))
-            print(debug_preambulo + "coincidencias " + str(coincidencias))
-            print(debug_preambulo + "sobrantes_en_osm: " + str(sobrantes_en_osm))
-            print(debug_preambulo + "sobrantes_esquema: " + str(sobrantes_esquema))
-        return ["NADA", None]
+            msj = ("{0} CASO NO CONTEMPLADO\n"
+                   "{0} total_osm: {1}\n"
+                   "{0} total_esquema: {2}\n"
+                   "{0} coincidencias: {3}\n"
+                   "{0} sobrantes_osm: {4}\n"
+                   "{0} sobrantes_esquema: {5}\n")
+            print(msj.format(debug_preambulo, total_osm, total_esquema,
+                             coincidencias, sobrantes_en_osm,
+                             sobrantes_esquema))
+        return None
 
-esquema_mapeo_global = parsear_esquema()
+
+esquema = parsear_esquema()
 
 if __name__ == "__main__":
-    '''
-    archivo_gpx = open(args.gpx, 'r')
-    gpx = gpxpy.parse(archivo_gpx)
-    archivo_gpx.close()
-    mostrar_waypoints(gpx)
-    mostrar_esquema(args.esquema)
-    '''
     ruta_gpx = args.gpx
     debug = args.debug
-
-    #caso info
-    #etiquetas_osm = {'amenity':'taxi'}
-    #etiquetas_esquema = {'amenity':'taxi'}
-    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
-
-    # caso editar
-    #etiquetas_osm ={'crossing': 'traffic_signals', 'highway': 'traffic_signals', 'traffic_signals': 'crossing'}
-    #etiquetas_esquema = {'crossing': 'traffic_signals', 'traffic_signals:sound': 'walk;yes'}
-    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
-
-    # caso revisar
-    #etiquetas_osm = {'bench': 'yes', 'bus': 'yes', 'covered': 'yes', 'highway': 'bus_stop', 'name': 'UNADECA', 'public_transport': 'platform', 'shelter': 'yes'}
-    #etiquetas_esquema = {'public_transport': 'platform', 'bench': 'yes', 'shelter': 'yes', 'bus': 'yes'}
-    #print(analizar_etiquetas(etiquetas_osm, etiquetas_esquema))
-
     analizar_traza(ruta_gpx, debug)

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -35,7 +35,8 @@ def parsear_esquema() -> dict:
     return esquema_parseado
 
 
-def descargar_nodos_en_rango(lat: float, lon: float, debug=False) -> list:
+def descargar_nodos_en_rango(lat: float, lon: float,
+                             debug=False) -> [overpy.Node]:
     """
     A partir de un punto (lat, lon) dado como argumento, descarga
     todos los nodos que se encuentren a una distancia de 'rango'
@@ -48,13 +49,14 @@ def descargar_nodos_en_rango(lat: float, lon: float, debug=False) -> list:
     # Consulta descarga nodos, pero si se cambia "node"
     # por "nwr" descarga vías y relaciones.
     consulta = "node(around:%s, %s, %s); out;" % (args.rango, lat, lon)
-    resultado = api.query(consulta)
+    descarga_nodos = api.query(consulta)
     if debug:
-        mostrar_nodos_descargados(resultado)
-    return resultado
+        mostrar_nodos_descargados(descarga_nodos)
+    return descarga_nodos
 
 
-def mostrar_nodos_descargados(resultado: list, mostrar_etiquetas=True) -> None:
+def mostrar_nodos_descargados(nodos_descargados: [overpy.Node],
+                              mostrar_etiquetas=True) -> None:
     """
     Dada una lista de objetos overpy.Node los imprime en un
     formato como el siguiente:
@@ -68,8 +70,8 @@ def mostrar_nodos_descargados(resultado: list, mostrar_etiquetas=True) -> None:
     debug_preambulo = "DEBUG (mostrar_nodos_descargados): "
     url = "https://osm.org/node/"
     print('{0} Se descargaron {1} nodos.'.
-          format(debug_preambulo, len(resultado.nodes)))
-    for nodo in resultado.nodes:
+          format(debug_preambulo, len(nodos_descargados.nodes)))
+    for nodo in nodos_descargados.nodes:
         print('{:>10}{}'.format(url, nodo.id))
         if mostrar_etiquetas:
             for llave, valor in nodo.tags.items():
@@ -101,7 +103,8 @@ def imprimir_encabezado_waypoint(nombre: str,
     print(msj.format(nombre, latitud, longitud))
 
 
-def imprimir_crear(latitud, longitud, etiquetas_nuevas) -> None:
+def imprimir_crear(latitud: float, longitud: float,
+                   etiquetas_nuevas: dict) -> None:
     """
     Basado en una latitud y longitud indica que se debe crear un
     nodo con ciertas etiquetas en esa coordenada especifica.
@@ -164,7 +167,7 @@ def imprimir_revisar(argumentos_imprimir: (int, dict, float, float)) -> None:
         etiquetas_sobrantes, indent=4)[1:-1]))
 
 
-def imprimir_resultado(resultado: tuple, id: int,
+def imprimir_resultado(resultado: (callable, dict), id: int,
                        latitud: float, longitud: float) -> None:
     """
     Recibe un resultado retornado de la forma
@@ -231,8 +234,8 @@ def analizar_traza(ruta_gpx: str, debug=False) -> None:
                 imprimir_crear(latitud, longitud, etiquetas_esquema)
 
 
-def analizar_etiquetas(etiquetas_osm: dict,
-                       etiquetas_esquema: dict, debug=True) -> tuple:
+def analizar_etiquetas(etiquetas_osm: dict, etiquetas_esquema: dict,
+                       debug=True) -> (callable, dict):
     """
     Segun las etiquetas en osm cercanas y las etiquetas en el
     esquema de cierto waypoint, determina cual es la funcion
@@ -270,7 +273,7 @@ def analizar_etiquetas(etiquetas_osm: dict,
     total_esquema = len(etiquetas_esquema)
 
     coincidencias = dict(etiquetas_osm.items() & etiquetas_esquema.items())
-    # "sobrantes_en_osm": están en OSM y no en el esquema.
+    # sobrantes_en_osm: están en OSM y no en el esquema.
     sobrantes_en_osm = dict(etiquetas_osm.items() - etiquetas_esquema.items())
     # sobrantes_esquema: están en el esquema y no en OSM
     sobrantes_esquema = dict(etiquetas_esquema.items() - etiquetas_osm.items())


### PR DESCRIPTION
Se incluye el cumplimiento del estándar de PEP 8  y las siguientes mejoras:
 

- `imprimir_resultado` no requiere de condicionales.
- Tipado de parámetros y valores de retorno en funciones.
- Mejoras de formatos en mensajes de _debug_.
- Exclusión de `mostrar_waypoints` sin ningún uso.