### PR TITLE
Añade funciones para reducir las consultas a overpass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pre Editor OSM
 
 ### Descripción     
-Este proyecto tiene como objetivo validar los datos de un GPX para devolver un informe que indique si la información existe en OSM está correcta, debe ser actualizada o no existe. A esta validación le llamamos pre edición, siendo que es un apoyo previo al proceso de editar el mapa.
+Este proyecto tiene como objetivo validar los datos de un GPX para devolver un informe que indique si la información existente en OSM está correcta, debe ser actualizada o no existe. A esta validación le llamamos pre edición, siendo que es un apoyo previo al proceso de editar el mapa.
 
 **Bibliotecas utilizadas**
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Pre Editor OSM 
+# Pre Editor OSM
 
 ### Descripción     
-Este proyecto tiene como objetivo validar los datos de un GPX para devolver un informe que indique si la información existe en OSM está correcta, debe ser actualizada o no existe. A esta validación le llamamos pre edición, siendo que es un apoyo previo al proceso de editar el mapa. 
+Este proyecto tiene como objetivo validar los datos de un GPX para devolver un informe que indique si la información existe en OSM está correcta, debe ser actualizada o no existe. A esta validación le llamamos pre edición, siendo que es un apoyo previo al proceso de editar el mapa.
 
 **Bibliotecas utilizadas**
 
 * [gpxpy](https://pypi.org/project/gpxpy/) para la extracción de puntos del gpx.
 * [overpy](https://github.com/DinoTools/python-overpy)  para descargar nodos desde OSM.
+* [geopy](https://github.com/geopy/geopy) para calcula la distancia entre ubicaciones.
 
 **Requerimientos y ejecución**
 

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -35,6 +35,56 @@ def parsear_esquema() -> dict:
     return esquema_parseado
 
 
+def obtener_cuadro_delimitador_de_gpx(gpx: gpxpy.gpx.GPX, debug=False) -> (int):
+    """
+    Calcula las coordendas del cuadro delimitador (`bbox`) más pequeño capaz
+    de contener los puntos de referencia de la traza (`waypoints`). El orden de
+    las coordendas del cuadro delimitador es el utilizado por Overpass, el cual
+    es:
+    (latitud inferior, longitud inferior, latitud superior, longitud superior)
+    """
+    # índices constantes
+    LATITUD_INFERIOR, LONGITUD_INFERIOR = 0, 1
+    LATITUD_SUPERIOR, LONGITUD_SUPERIOR = 2, 3
+
+    lat, lon = gpx.waypoints[0].latitude, gpx.waypoints[0].longitude
+    # [latitud inferior, longitud inferior, latitud superior, longitud superior]
+    cuadro = [lat, lon, lat, lon]
+
+    # revisa los puntos de cada punto de refrencia
+    for waypoint in gpx.waypoints[1:]:
+        if waypoint.latitude < cuadro[LATITUD_INFERIOR]:
+            cuadro[LATITUD_INFERIOR] = waypoint.latitude
+        if waypoint.latitude > cuadro[LATITUD_SUPERIOR]:
+            cuadro[LATITUD_SUPERIOR] = waypoint.latitude
+
+        if waypoint.longitude < cuadro[LONGITUD_INFERIOR]:
+            cuadro[LONGITUD_INFERIOR] = waypoint.longitude
+        if waypoint.longitude > cuadro[LONGITUD_SUPERIOR]:
+            cuadro[LONGITUD_SUPERIOR] = waypoint.longitude
+
+    if debug:
+        print("El cuadro es: ", cuadro)
+
+    return tuple(cuadro)
+
+
+def descargar_nodos_en_cuadro_delimitador(cuadro : (int),
+                                          debug=False) -> [overpy.Node]:
+    """
+    Descarga todos los nodos con al menos una etiqueta ubicados dentro de las
+    coordendas del cuadro delimitador.
+
+    Devuelve una lista de objetos overpy.Node.
+    """
+    api = overpy.Overpass()
+    consulta = "node" +str(cuadro) + "(if:count_tags() > 0); out;"
+    descarga_nodos = api.query(consulta)
+    if debug:
+        mostrar_nodos_descargados(descarga_nodos)
+    return descarga_nodos
+
+
 def descargar_nodos_en_rango(lat: float, lon: float,
                              debug=False) -> [overpy.Node]:
     """
@@ -319,4 +369,16 @@ esquema = parsear_esquema()
 if __name__ == "__main__":
     ruta_gpx = args.gpx
     debug = args.debug
-    analizar_traza(ruta_gpx, debug)
+    # analizar_traza(ruta_gpx, debug)
+
+
+    ## Pruebas del método descargar nodos en cuadro delimitador
+
+    # TODO: eliminar estos dos líneas
+    archivo_gpx = open(ruta_gpx, 'r')
+    gpx = gpxpy.parse(archivo_gpx)
+    cuadro = obtener_cuadro_delimitador_de_gpx(gpx, True)
+    # TODO: eliminar esta línea
+    archivo_gpx.close()
+
+    descargar_nodos_en_cuadro_delimitador(cuadro, True)

--- a/pre_editor.py
+++ b/pre_editor.py
@@ -77,12 +77,13 @@ def descargar_nodos_en_cuadro_delimitador(cuadro : (int),
     coordendas del cuadro delimitador.
     """
     api = overpy.Overpass()
-    consulta = "node" +str(cuadro) + "(if:count_tags() > 0); out;"
-    descarga_nodos = api.query(consulta)
+    consulta = "node" + str(cuadro) + "(if:count_tags() > 0); out;"
+    nodos_descargados = api.query(consulta).get_nodes()
     if debug:
-        print("Número de nodos con al menos una etiqueta: ", len(nodos_totales))
-        mostrar_nodos_descargados(descarga_nodos)
-    return descarga_nodos.get_nodes()
+        print("Número de nodos con al menos una etiqueta: ",
+              len(nodos_descargados))
+        mostrar_nodos_descargados(nodos_descargados)
+    return nodos_descargados
 
 
 def obtener_nodos_en_rango(nodos_totales: [overpy.Node], lat: float, lon: float,
@@ -119,8 +120,8 @@ def mostrar_nodos_descargados(nodos_descargados: [overpy.Node],
     debug_preambulo = "DEBUG (mostrar_nodos_descargados): "
     url = "https://osm.org/node/"
     print('{0} Se descargaron {1} nodos.'.
-          format(debug_preambulo, len(nodos_descargados.nodes)))
-    for nodo in nodos_descargados.nodes:
+          format(debug_preambulo, len(nodos_descargados)))
+    for nodo in nodos_descargados:
         print('{:>10}{}'.format(url, nodo.id))
         if mostrar_etiquetas:
             for llave, valor in nodo.tags.items():

--- a/requerimientos.txt
+++ b/requerimientos.txt
@@ -1,2 +1,3 @@
 gpxpy==1.4.2
 overpy>=0.4
+geopy>=2.2.0


### PR DESCRIPTION
Este PR contiene dos nuevas funciones: `obtener_cuadro_delimitador_de_gpx` y `descargar_nodos_en_cuadro_delimitador`. 

~~Falta por implementar una función que determine si un punto está dentro de un rango de metros usando los datos descargados, con lo cual se lograría reducir a una las consultas que actualmente se realizan al API de overpass.~~

Tambíen se añadió una tercera función llamada `obtener_nodos_en_rango`. 

Con estas tres funciones implementadas, se eliminó la necesidad de hacer múltiples consultas al API de overpass.